### PR TITLE
register Doctrine functions automatically while providing a way to set custom names

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Craue\GeoBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Semantic bundle configuration.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class Configuration implements ConfigurationInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getConfigTreeBuilder() {
+		$treeBuilder = new TreeBuilder();
+
+		$treeBuilder->root('craue_geo')
+			->children()
+				->arrayNode('functions')
+					->addDefaultsIfNotSet()
+					->children()
+						->scalarNode('geo_distance')->defaultValue('GEO_DISTANCE')->end()
+						->scalarNode('geo_distance_by_postal_code')->defaultValue('GEO_DISTANCE_BY_POSTAL_CODE')->end()
+					->end()
+				->end()
+			->end()
+		;
+
+		return $treeBuilder;
+	}
+
+}

--- a/DependencyInjection/CraueGeoExtension.php
+++ b/DependencyInjection/CraueGeoExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Craue\GeoBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+/**
+ * Registration of the extension via DI.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class CraueGeoExtension extends Extension implements PrependExtensionInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function load(array $config, ContainerBuilder $container) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prepend(ContainerBuilder $container) {
+		$config = $this->processConfiguration(new Configuration(), $container->getExtensionConfig($this->getAlias()));
+
+		$container->prependExtensionConfig('doctrine', array(
+			'orm' => array(
+				'dql' => array(
+					'numeric_functions' => array(
+						$config['functions']['geo_distance'] => 'Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
+						$config['functions']['geo_distance_by_postal_code'] => 'Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode',
+					),
+				),
+			),
+		));
+	}
+
+}

--- a/README.md
+++ b/README.md
@@ -32,21 +32,6 @@ public function registerBundles() {
 }
 ```
 
-## Register the Doctrine functions you need
-
-You need to manually register the Doctrine functions you want to use.
-See http://symfony.com/doc/current/cookbook/doctrine/custom_dql_functions.html for details.
-
-```yaml
-# in app/config/config.yml
-doctrine:
-  orm:
-    dql:
-      numeric_functions:
-        GEO_DISTANCE: Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance
-        GEO_DISTANCE_BY_POSTAL_CODE: Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode
-```
-
 ## Prepare the table with geographical data needed for calculations
 
 The `GEO_DISTANCE_BY_POSTAL_CODE` function, if you'd like to use it, relies on some data which has to be added to your
@@ -139,3 +124,17 @@ $queryBuilder
 ```
 
 The `HIDDEN` keyword is available as of Doctrine 2.2.
+
+# Advanced stuff
+
+## Use custom names for the Doctrine functions
+
+If you don't like the default names or need to avoid conflicts with other functions, you can set custom names:
+
+```yaml
+# in app/config/config.yml
+craue_geo:
+  functions:
+    geo_distance: MY_VERY_OWN_GEO_DISTANCE_FUNCTION
+    geo_distance_by_postal_code: MY_VERY_OWN_GEO_DISTANCE_BY_POSTAL_CODE_FUNCTION
+```

--- a/Tests/Doctrine/Fixtures/FixtureTest.php
+++ b/Tests/Doctrine/Fixtures/FixtureTest.php
@@ -15,21 +15,23 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
 class FixtureTest extends IntegrationTestCase {
 
 	public function testImport() {
+		$this->initClient();
+
 		// [A] add some data which is meant to be removed by importing new data
-		static::persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
+		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
 
 		// import new data using the fixture
 		$fixture = new PuertoRicoGeonamesPostalCodeData();
 		ob_start();
-		$fixture->load(static::getEntityManager());
+		$fixture->load($this->getEntityManager());
 		$output = ob_get_clean();
 		$this->assertEquals(" 177\n", $output);
 
 		// [A] verify that old data has been removed
-		$this->assertCount(0, static::getRepo()->findBy(array('country' => 'DE')));
+		$this->assertCount(0, $this->getRepo()->findBy(array('country' => 'DE')));
 
 		// verify that new data was imported as expected
-		$this->assertCount(177, static::getRepo()->findAll());
+		$this->assertCount(177, $this->getRepo()->findAll());
 	}
 
 }

--- a/Tests/Doctrine/Query/Mysql/CustomFunctionNameTest.php
+++ b/Tests/Doctrine/Query/Mysql/CustomFunctionNameTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Craue\GeoBundle\Tests\Doctrine\Query\Mysql;
+
+use Craue\GeoBundle\Tests\IntegrationTestCase;
+
+/**
+ * @group integration
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class CustomFunctionNameTest extends IntegrationTestCase {
+
+	/**
+	 * Ensure that custom function names will be used to register the corresponding functions.
+	 */
+	public function testCustomFunctionName() {
+		$this->initClient(array('environment' => 'customFunctionName', 'config' => 'config_customFunctionName.yml'));
+		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
+				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('CRAUE_GEO_DISTANCE'));
+		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode',
+				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('CRAUE_GEO_DISTANCE_BY_POSTAL_CODE'));
+	}
+
+	/**
+	 * Ensure that a user-defined function will override the bundle-defined default one to preserve BC.
+	 */
+	public function testOverrideFunction() {
+		$this->initClient(array('environment' => 'overrideFunction', 'config' => 'config_overrideFunction.yml'));
+		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
+				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('MY_GEO_DISTANCE'));
+	}
+
+}

--- a/Tests/Doctrine/Query/Mysql/GeoDistanceByPostalCodeTest.php
+++ b/Tests/Doctrine/Query/Mysql/GeoDistanceByPostalCodeTest.php
@@ -13,6 +13,10 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
  */
 class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 
+	protected function setUp() {
+		$this->initClient();
+	}
+
 	public function testNoResults() {
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '10551');
 
@@ -20,8 +24,8 @@ class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 	}
 
 	public function testDistance() {
-		static::persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
-		static::persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
+		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
+		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '10551');
 
@@ -31,8 +35,8 @@ class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 	}
 
 	public function testUnknownPostalCode_withRadius() {
-		static::persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
-		static::persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
+		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
+		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '20099', 1000.1);
 
@@ -40,8 +44,8 @@ class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 	}
 
 	public function testUnknownPostalCode_withoutRadius() {
-		static::persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
-		static::persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
+		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
+		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '20099');
 

--- a/Tests/Doctrine/Query/Mysql/GeoDistanceTest.php
+++ b/Tests/Doctrine/Query/Mysql/GeoDistanceTest.php
@@ -14,24 +14,25 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
 class GeoDistanceTest extends IntegrationTestCase {
 
 	/**
-	 * {@inheritDoc}
+	 * @var boolean
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	private static $dummyDataAdded = false;
 
-		// there must be any data in the table to get a result at all, but it's fine to only add the dummy data once
-		static::persistDummyGeoPostalCodes(1);
-	}
+	protected function setUp() {
+		$this->initClient(array(), !self::$dummyDataAdded);
 
-	protected function cleanDatabaseBeforeTest() {
-		// don't clean
+		// There must be some data in the table to get a result at all, but it's fine to only add the dummy data once.
+		if (!self::$dummyDataAdded) {
+			$this->persistDummyGeoPostalCodes(1);
+			self::$dummyDataAdded = true;
+		}
 	}
 
 	/**
 	 * @dataProvider dataGeoDistance
 	 */
 	public function testGeoDistance($latOrigin, $lngOrigin, $latDestination, $lngDestination, $expectedDistance) {
-		$qb = static::getRepo()->createQueryBuilder('poi')
+		$qb = $this->getRepo()->createQueryBuilder('poi')
 			->select('GEO_DISTANCE(:latOrigin, :lngOrigin, :latDestination, :lngDestination)')
 			->setParameter('latOrigin', $latOrigin)
 			->setParameter('lngOrigin', $lngOrigin)

--- a/Tests/Doctrine/Query/Mysql/TimingTest.php
+++ b/Tests/Doctrine/Query/Mysql/TimingTest.php
@@ -16,17 +16,18 @@ class TimingTest extends IntegrationTestCase {
 	const NUMBER_OF_POIS = 50000;
 
 	/**
-	 * {@inheritDoc}
+	 * @var boolean
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	private static $dummyDataAdded = false;
 
-		// only add the dummy data once as it takes quite some time
-		static::persistDummyGeoPostalCodes(static::NUMBER_OF_POIS);
-	}
+	protected function setUp() {
+		$this->initClient(array(), !self::$dummyDataAdded);
 
-	protected function cleanDatabaseBeforeTest() {
-		// don't clean
+		// Only add the dummy data once as it takes quite some time.
+		if (!self::$dummyDataAdded) {
+			$this->persistDummyGeoPostalCodes(static::NUMBER_OF_POIS);
+			self::$dummyDataAdded = true;
+		}
 	}
 
 	public function testTimingGeoDistance_withRadius() {

--- a/Tests/config/config.yml
+++ b/Tests/config/config.yml
@@ -10,10 +10,6 @@ doctrine:
   orm:
     auto_generate_proxy_classes: "%kernel.debug%"
     auto_mapping: true
-    dql:
-      numeric_functions:
-        GEO_DISTANCE: Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance
-        GEO_DISTANCE_BY_POSTAL_CODE: Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode
 
 framework:
   router:

--- a/Tests/config/config_customFunctionName.yml
+++ b/Tests/config/config_customFunctionName.yml
@@ -1,0 +1,7 @@
+imports:
+  - { resource: config.yml }
+
+craue_geo:
+  functions:
+    geo_distance: CRAUE_GEO_DISTANCE
+    geo_distance_by_postal_code: CRAUE_GEO_DISTANCE_BY_POSTAL_CODE

--- a/Tests/config/config_overrideFunction.yml
+++ b/Tests/config/config_overrideFunction.yml
@@ -1,0 +1,12 @@
+imports:
+  - { resource: config.yml }
+
+doctrine:
+  orm:
+    dql:
+      numeric_functions:
+        MY_GEO_DISTANCE: Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance
+
+craue_geo:
+  functions:
+    geo_distance_by_postal_code: MY_GEO_DISTANCE


### PR DESCRIPTION
With this, a user doesn't need to register the Doctrine functions manually anymore. They are just registered using their usual names. Configuration is added to set custom names, if needed.

There should be no BC break. If a user already uses different names for these function, they will still work. Also, if a user defined other functions named like the bundle defaults, the user-defined ones will have precedence.