### PR TITLE
add a config option to avoid creating the postal code table

### DIFF
--- a/CraueGeoBundle.php
+++ b/CraueGeoBundle.php
@@ -2,6 +2,8 @@
 
 namespace Craue\GeoBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -10,4 +12,24 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
 class CraueGeoBundle extends Bundle {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function build(ContainerBuilder $container) {
+		parent::build($container);
+		$this->addRegisterMappingsPass($container);
+	}
+
+	/**
+	 * @param ContainerBuilder $container
+	 */
+	private function addRegisterMappingsPass(ContainerBuilder $container) {
+		$mappings = array(
+			realpath(__DIR__ . '/Resources/config/doctrine-mapping') => 'Craue\GeoBundle\Entity',
+		);
+
+		$container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, array(), 'craue_geo.register_entity.postal_code'));
+	}
+
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface {
 
 		$treeBuilder->root('craue_geo')
 			->children()
+				->booleanNode('enable_postal_code_entity')->defaultValue(true)->end()
 				->arrayNode('functions')
 					->addDefaultsIfNotSet()
 					->children()

--- a/DependencyInjection/CraueGeoExtension.php
+++ b/DependencyInjection/CraueGeoExtension.php
@@ -27,6 +27,10 @@ class CraueGeoExtension extends Extension implements PrependExtensionInterface {
 	public function prepend(ContainerBuilder $container) {
 		$config = $this->processConfiguration(new Configuration(), $container->getExtensionConfig($this->getAlias()));
 
+		if ($config['enable_postal_code_entity'] === true) {
+			$container->setParameter('craue_geo.register_entity.postal_code', true);
+		}
+
 		$container->prependExtensionConfig('doctrine', array(
 			'orm' => array(
 				'dql' => array(

--- a/Entity/GeoPostalCode.php
+++ b/Entity/GeoPostalCode.php
@@ -2,17 +2,9 @@
 
 namespace Craue\GeoBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * @ORM\Entity
- * @ORM\Table(name="craue_geo_postalcode",
- * 	uniqueConstraints={@ORM\UniqueConstraint(name="postal_code_idx", columns={
- * 		"country", "postal_code"
- * 	})}
- * )
- *
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2015 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
@@ -21,36 +13,29 @@ class GeoPostalCode {
 
 	/**
 	 * @var integer
-	 * @ORM\Column(name="id", type="integer", nullable=false)
-	 * @ORM\Id
-	 * @ORM\GeneratedValue(strategy="AUTO")
 	 */
 	protected $id;
 
 	/**
 	 * @var string
-	 * @ORM\Column(name="country", type="string", length=2, nullable=false)
 	 * @Assert\NotBlank
 	 */
 	protected $country;
 
 	/**
 	 * @var string
-	 * @ORM\Column(name="postal_code", type="string", length=20, nullable=false)
 	 * @Assert\NotBlank
 	 */
 	protected $postalCode;
 
 	/**
 	 * @var double
-	 * @ORM\Column(name="lat", type="decimal", precision=9, scale=6, nullable=false)
 	 * @Assert\NotBlank
 	 */
 	protected $lat;
 
 	/**
 	 * @var double
-	 * @ORM\Column(name="lng", type="decimal", precision=9, scale=6, nullable=false)
 	 * @Assert\NotBlank
 	 */
 	protected $lng;

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ The `HIDDEN` keyword is available as of Doctrine 2.2.
 
 # Advanced stuff
 
+## Avoid creating the postal code table
+
+If you want to avoid registering the `GeoPostalCode` entity (and as a result, avoid creating the `craue_geo_postalcode` table) at all, add
+
+```yaml
+# in app/config/config.yml
+craue_geo:
+  enable_postal_code_entity: false
+```
+
+to your configuration.
+
 ## Use custom names for the Doctrine functions
 
 If you don't like the default names or need to avoid conflicts with other functions, you can set custom names:

--- a/Resources/config/doctrine-mapping/GeoPostalCode.orm.xml
+++ b/Resources/config/doctrine-mapping/GeoPostalCode.orm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2015 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<doctrine-mapping
+	xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+	<entity name="Craue\GeoBundle\Entity\GeoPostalCode" table="craue_geo_postalcode">
+		<unique-constraints>
+			<unique-constraint name="postal_code_idx" columns="country,postal_code" />
+		</unique-constraints>
+		<id name="id" column="id" type="integer">
+			<generator strategy="AUTO" />
+		</id>
+		<field name="country" column="country" type="string" length="2" nullable="false" />
+		<field name="postalCode" column="postal_code" type="string" length="20" nullable="false" />
+		<field name="lat" column="lat" type="decimal" precision="9" scale="6" nullable="false" />
+		<field name="lng" column="lng" type="decimal" precision="9" scale="6" nullable="false" />
+	</entity>
+</doctrine-mapping>

--- a/Tests/Doctrine/Query/Mysql/DisablePostalCodeEntityTest.php
+++ b/Tests/Doctrine/Query/Mysql/DisablePostalCodeEntityTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Craue\GeoBundle\Tests\Doctrine\Query\Mysql;
+
+use Craue\GeoBundle\Tests\IntegrationTestCase;
+
+/**
+ * @group integration
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DisablePostalCodeEntityTest extends IntegrationTestCase {
+
+	/**
+	 * Ensure that the GeoPostalCode class is not registered as a Doctrine entity.
+	 *
+	 * @expectedException Doctrine\ORM\Mapping\MappingException
+	 * @expectedExceptionMessage Class "Craue\GeoBundle\Entity\GeoPostalCode"
+	 * @expectedExceptionMessage is not a valid entity or mapped super class.
+	 *
+	 * Note: Doctrine ORM 2.3.0 would throw an exception with message
+	 *   Class "Craue\GeoBundle\Entity\GeoPostalCode" sub class of "" is not a valid entity or mapped super class.
+	 * here, so just verify the relevant parts of the message. This has been fixed in ORM 2.3.1.
+	 */
+	public function testDisablePostalCodeEntity() {
+		$this->initClient(array('environment' => 'disablePostalCodeEntity', 'config' => 'config_disablePostalCodeEntity.yml'));
+		$this->getRepo();
+	}
+
+}

--- a/Tests/config/config_disablePostalCodeEntity.yml
+++ b/Tests/config/config_disablePostalCodeEntity.yml
@@ -1,0 +1,5 @@
+imports:
+  - { resource: config.yml }
+
+craue_geo:
+  enable_postal_code_entity: false

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
+		"doctrine/doctrine-bundle": "~1.3",
+		"doctrine/orm": "~2.3",
 		"symfony/framework-bundle": "~2.3"
 	},
 	"require-dev": {
-		"doctrine/orm": "~2.3",
 		"doctrine/data-fixtures": "~1.0",
-		"doctrine/doctrine-bundle": "~1.0",
 		"phpunit/phpunit": "~4.1",
 		"symfony/symfony": "~2.3"
 	},
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.2.x-dev"
+			"dev-master": "1.3.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
The new config option `enable_postal_code_entity` can be set to `false` to avoid registering the `GeoPostalCode` entity (and as a result, avoid creating the `craue_geo_postalcode` table) as requested in #8.

Closes #8.