### PR TITLE
add support for PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - env: SYMFONY_VERSION='3.3.*' MIN_STABILITY='dev'
   fast_finish: true
 
+services:
+  - postgresql
+
 install:
   - if [ "${TRAVIS_PHP_VERSION}" != 'hhvm' ]; then phpenv config-rm xdebug.ini; fi;
   - if [ "${TRAVIS_PHP_VERSION}" != 'hhvm' ]; then INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; else INI_FILE=/etc/hhvm/php.ini; fi;
@@ -40,6 +43,7 @@ install:
 
 before_script:
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+  - psql -c 'create database test;' -U postgres
 
 script: vendor/bin/phpunit -v
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface {
 
 		$treeBuilder->root('craue_geo')
 			->children()
+				->enumNode('flavor')->values(array('none', 'mysql', 'postgresql'))->defaultValue('mysql')->end()
 				->booleanNode('enable_postal_code_entity')->defaultValue(true)->end()
 				->arrayNode('functions')
 					->addDefaultsIfNotSet()

--- a/DependencyInjection/CraueGeoExtension.php
+++ b/DependencyInjection/CraueGeoExtension.php
@@ -31,16 +31,20 @@ class CraueGeoExtension extends Extension implements PrependExtensionInterface {
 			$container->setParameter('craue_geo.register_entity.postal_code', true);
 		}
 
-		$container->prependExtensionConfig('doctrine', array(
-			'orm' => array(
-				'dql' => array(
-					'numeric_functions' => array(
-						$config['functions']['geo_distance'] => 'Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
-						$config['functions']['geo_distance_by_postal_code'] => 'Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode',
+		if ($config['flavor'] !== 'none') {
+			$functionClassesNamespace = sprintf('Craue\GeoBundle\Doctrine\Query\%s', ucfirst($config['flavor']));
+
+			$container->prependExtensionConfig('doctrine', array(
+				'orm' => array(
+					'dql' => array(
+						'numeric_functions' => array(
+							$config['functions']['geo_distance'] => sprintf('%s\GeoDistance', $functionClassesNamespace),
+							$config['functions']['geo_distance_by_postal_code'] => sprintf('%s\GeoDistanceByPostalCode', $functionClassesNamespace),
+						),
 					),
 				),
-			),
-		));
+			));
+		}
 	}
 
 }

--- a/Doctrine/Query/Mysql/GeoDistance.php
+++ b/Doctrine/Query/Mysql/GeoDistance.php
@@ -45,7 +45,7 @@ class GeoDistance extends FunctionNode {
 		// formula adapted from http://www.scribd.com/doc/2569355/Geo-Distance-Search-with-MySQL
 		// originally returns distance in miles: 3956 * 2 * ASIN(SQRT(POWER(SIN((orig.lat - dest.lat) * PI()/180 / 2), 2) + COS(orig.lat * PI()/180) * COS(dest.lat * PI()/180) * POWER(SIN((orig.lon - dest.lon) * PI()/180 / 2), 2)))
 		return sprintf(
-			'%s * ASIN(SQRT(POWER(SIN((%s - %s) * PI()/360), 2) + COS(%s * PI()/180) * COS(%s * PI()/180) * POWER(SIN((%s - %s) * PI()/360), 2)))',
+			$this->getSqlWithPlaceholders(),
 			self::EARTH_DIAMETER,
 			$sqlWalker->walkArithmeticPrimary($this->latOrigin),
 			$sqlWalker->walkArithmeticPrimary($this->latDestination),
@@ -54,6 +54,10 @@ class GeoDistance extends FunctionNode {
 			$sqlWalker->walkArithmeticPrimary($this->lngOrigin),
 			$sqlWalker->walkArithmeticPrimary($this->lngDestination)
 		);
+	}
+
+	protected function getSqlWithPlaceholders() {
+		return '%s * ASIN(SQRT(POWER(SIN((%s - %s) * PI()/360), 2) + COS(%s * PI()/180) * COS(%s * PI()/180) * POWER(SIN((%s - %s) * PI()/360), 2)))';
 	}
 
 }

--- a/Doctrine/Query/Mysql/GeoDistanceByPostalCode.php
+++ b/Doctrine/Query/Mysql/GeoDistanceByPostalCode.php
@@ -37,7 +37,7 @@ class GeoDistanceByPostalCode extends FunctionNode {
 
 	public function getSql(SqlWalker $sqlWalker) {
 		return sprintf(
-			'%s * ASIN(SQRT(POWER(SIN(((SELECT `lat` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s) - (SELECT `lat` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s)) * PI()/360), 2) + COS((SELECT `lat` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s) * PI()/180) * COS((SELECT `lat` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s) * PI()/180) * POWER(SIN(((SELECT `lng` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s) - (SELECT `lng` FROM `craue_geo_postalcode` WHERE `country` = %s AND `postal_code` = %s)) * PI()/360), 2)))',
+			'%s * ASIN(SQRT(POWER(SIN(((SELECT lat FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s) - (SELECT lat FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s)) * PI()/360), 2) + COS((SELECT lat FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s) * PI()/180) * COS((SELECT lat FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s) * PI()/180) * POWER(SIN(((SELECT lng FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s) - (SELECT lng FROM craue_geo_postalcode WHERE country = %s AND postal_code = %s)) * PI()/360), 2)))',
 			GeoDistance::EARTH_DIAMETER,
 			$sqlWalker->walkStringPrimary($this->countryOrigin),
 			$sqlWalker->walkStringPrimary($this->postalCodeOrigin),

--- a/Doctrine/Query/Postgresql/GeoDistance.php
+++ b/Doctrine/Query/Postgresql/GeoDistance.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Craue\GeoBundle\Doctrine\Query\Postgresql;
+
+use Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance as BaseGeoDistance;
+
+/**
+ * {@inheritDoc}
+ */
+class GeoDistance extends BaseGeoDistance {
+
+	protected function getSqlWithPlaceholders() {
+		return '%s * ASIN(SQRT(POWER(SIN((CAST(%s AS numeric) - CAST(%s AS numeric)) * PI()/360), 2) + COS(%s * PI()/180) * COS(%s * PI()/180) * POWER(SIN((CAST(%s AS numeric) - CAST(%s AS numeric)) * PI()/360), 2)))';
+	}
+
+}

--- a/Doctrine/Query/Postgresql/GeoDistanceByPostalCode.php
+++ b/Doctrine/Query/Postgresql/GeoDistanceByPostalCode.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Craue\GeoBundle\Doctrine\Query\Postgresql;
+
+use Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode as BaseGeoDistanceByPostalCode;
+
+/**
+ * {@inheritDoc}
+ */
+class GeoDistanceByPostalCode extends BaseGeoDistanceByPostalCode {
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two Doctrine functions, which return a distance in km:
 Let Composer download and install the bundle by running
 
 ```sh
-php composer.phar require craue/geo-bundle:~1.3
+php composer.phar require craue/geo-bundle:~1.4@dev
 ```
 
 in a shell.
@@ -126,6 +126,37 @@ $queryBuilder
 The `HIDDEN` keyword is available as of Doctrine 2.2.
 
 # Advanced stuff
+
+## Using the Doctrine functions for a different database platform
+
+By default, the Doctrine functions are automatically registered for usage with MySQL. But you can tell the bundle that
+you want to use them with a different database platform by setting a `flavor`:
+
+```yaml
+# in app/config/config.yml
+craue_geo:
+  flavor: postgresql
+```
+
+Currently, the following flavors are supported:
+- `mysql`: MySQL (default value)
+- `postgresql`: PostgreSQL
+- `none`: prevents registration of the Doctrine functions in case you want to do it manually
+
+As PostgreSQL doesn't support aliases in the HAVING clause and further requires `poi` to appear in the GROUP BY clause,
+you need to adapt the query (from the usage example above):
+
+```php
+$queryBuilder
+	->select('poi, GEO_DISTANCE_BY_POSTAL_CODE(:country, :postalCode, poi.country, poi.postalCode) AS HIDDEN distance')
+	->having('GEO_DISTANCE_BY_POSTAL_CODE(:country, :postalCode, poi.country, poi.postalCode) <= :radius')
+	->setParameter('country', $country)
+	->setParameter('postalCode', $postalCode)
+	->setParameter('radius', $radiusInKm)
+	->groupBy('poi')
+	->orderBy('distance')
+;
+```
 
 ## Avoid creating the postal code table
 

--- a/Tests/Doctrine/Fixtures/FixtureTest.php
+++ b/Tests/Doctrine/Fixtures/FixtureTest.php
@@ -14,8 +14,11 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
  */
 class FixtureTest extends IntegrationTestCase {
 
-	public function testImport() {
-		$this->initClient();
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testImport($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
 
 		// [A] add some data which is meant to be removed by importing new data
 		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);

--- a/Tests/Doctrine/Query/Mysql/CustomFunctionNameTest.php
+++ b/Tests/Doctrine/Query/Mysql/CustomFunctionNameTest.php
@@ -15,22 +15,40 @@ class CustomFunctionNameTest extends IntegrationTestCase {
 
 	/**
 	 * Ensure that custom function names will be used to register the corresponding functions.
+	 *
+	 * @dataProvider dataCustomFunctionName
 	 */
-	public function testCustomFunctionName() {
-		$this->initClient(array('environment' => 'customFunctionName', 'config' => 'config_customFunctionName.yml'));
-		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
+	public function testCustomFunctionName($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => 'customFunctionName_' . $platform, 'config' => $config));
+
+		$this->assertSame(sprintf('Craue\GeoBundle\Doctrine\Query\%s\GeoDistance', ucfirst($platform)),
 				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('CRAUE_GEO_DISTANCE'));
-		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistanceByPostalCode',
+		$this->assertSame(sprintf('Craue\GeoBundle\Doctrine\Query\%s\GeoDistanceByPostalCode', ucfirst($platform)),
 				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('CRAUE_GEO_DISTANCE_BY_POSTAL_CODE'));
+	}
+
+	public function dataCustomFunctionName() {
+		return self::duplicateTestDataForEachPlatform(array(
+			array(),
+		), 'config_customFunctionName.yml');
 	}
 
 	/**
 	 * Ensure that a user-defined function will override the bundle-defined default one to preserve BC.
+	 *
+	 * @dataProvider dataOverrideFunction
 	 */
-	public function testOverrideFunction() {
-		$this->initClient(array('environment' => 'overrideFunction', 'config' => 'config_overrideFunction.yml'));
+	public function testOverrideFunction($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => 'overrideFunction_' . $platform, 'config' => $config));
+
 		$this->assertSame('Craue\GeoBundle\Doctrine\Query\Mysql\GeoDistance',
 				$this->getEntityManager()->getConfiguration()->getCustomNumericFunction('MY_GEO_DISTANCE'));
+	}
+
+	public function dataOverrideFunction() {
+		return self::duplicateTestDataForEachPlatform(array(
+			array(),
+		), 'config_overrideFunction.yml');
 	}
 
 }

--- a/Tests/Doctrine/Query/Mysql/DisablePostalCodeEntityTest.php
+++ b/Tests/Doctrine/Query/Mysql/DisablePostalCodeEntityTest.php
@@ -16,6 +16,8 @@ class DisablePostalCodeEntityTest extends IntegrationTestCase {
 	/**
 	 * Ensure that the GeoPostalCode class is not registered as a Doctrine entity.
 	 *
+	 * @dataProvider dataDisablePostalCodeEntity
+	 *
 	 * @expectedException \Doctrine\ORM\Mapping\MappingException
 	 * @expectedExceptionMessage Class "Craue\GeoBundle\Entity\GeoPostalCode"
 	 * @expectedExceptionMessage is not a valid entity or mapped super class.
@@ -24,9 +26,16 @@ class DisablePostalCodeEntityTest extends IntegrationTestCase {
 	 *   Class "Craue\GeoBundle\Entity\GeoPostalCode" sub class of "" is not a valid entity or mapped super class.
 	 * here, so just verify the relevant parts of the message. This has been fixed in ORM 2.3.1.
 	 */
-	public function testDisablePostalCodeEntity() {
-		$this->initClient(array('environment' => 'disablePostalCodeEntity', 'config' => 'config_disablePostalCodeEntity.yml'));
+	public function testDisablePostalCodeEntity($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => 'disablePostalCodeEntity_' . $platform, 'config' => $config));
+
 		$this->getRepo();
+	}
+
+	public function dataDisablePostalCodeEntity() {
+		return self::duplicateTestDataForEachPlatform(array(
+			array(),
+		), 'config_disablePostalCodeEntity.yml');
 	}
 
 }

--- a/Tests/Doctrine/Query/Mysql/FlavorTest.php
+++ b/Tests/Doctrine/Query/Mysql/FlavorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Craue\GeoBundle\Tests\Doctrine\Query\Mysql;
+
+use Craue\GeoBundle\Tests\IntegrationTestCase;
+
+/**
+ * @group integration
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2017 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class FlavorTest extends IntegrationTestCase {
+
+	/**
+	 * Ensure that only valid values can be used for the flavor.
+	 *
+	 * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+	 * @expectedExceptionMessage The value "invalid" is not allowed for path "craue_geo.flavor". Permissible values: "none", "mysql", "postgresql"
+	 */
+	public function testFlavorInvalid() {
+		$this->initClient(null, array('environment' => 'invalidFlavor', 'config' => array('config.yml', 'config_flavor_invalid.yml')));
+	}
+
+	/**
+	 * Ensure that function GEO_DISTANCE is not registered when using flavor 'none'.
+	 *
+	 * @expectedException \Doctrine\ORM\Query\QueryException
+	 * @expectedExceptionMessage Error: Expected known function, got 'GEO_DISTANCE'
+	 */
+	public function testFlavorNone_geoDistance() {
+		$this->initClient(null, array('environment' => 'flavorNone', 'config' => array('config.yml', 'config_flavor_none.yml')));
+
+		$this->getPoisPerGeoDistance(52.1, 13.1, 1);
+	}
+
+	/**
+	 * Ensure that function GEO_DISTANCE_BY_POSTAL_CODE is not registered when using flavor 'none'.
+	 *
+	 * @expectedException \Doctrine\ORM\Query\QueryException
+	 * @expectedExceptionMessage Error: Expected known function, got 'GEO_DISTANCE_BY_POSTAL_CODE'
+	 */
+	public function testFlavorNone_geoDistanceByPostalCode() {
+		$this->initClient(null, array('environment' => 'flavorNone', 'config' => array('config.yml', 'config_flavor_none.yml')));
+
+		$this->getPoisPerGeoDistanceByPostalCode('DE', '123');
+	}
+
+}

--- a/Tests/Doctrine/Query/Mysql/GeoDistanceByPostalCodeTest.php
+++ b/Tests/Doctrine/Query/Mysql/GeoDistanceByPostalCodeTest.php
@@ -13,17 +13,23 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
  */
 class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 
-	protected function setUp() {
-		$this->initClient();
-	}
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testNoResults($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
 
-	public function testNoResults() {
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '10551');
 
 		$this->assertCount(0, $result);
 	}
 
-	public function testDistance() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testDistance($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
+
 		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
 		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 
@@ -34,7 +40,12 @@ class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 		$this->assertEquals(25.324980933453528, $result[1]['distance']);
 	}
 
-	public function testUnknownPostalCode_withRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testUnknownPostalCode_withRadius($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
+
 		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
 		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 
@@ -43,7 +54,12 @@ class GeoDistanceByPostalCodeTest extends IntegrationTestCase {
 		$this->assertCount(0, $result);
 	}
 
-	public function testUnknownPostalCode_withoutRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testUnknownPostalCode_withoutRadius($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
+
 		$this->persistGeoPostalCode('DE', '14473', 52.392759, 13.065135);
 		$this->persistGeoPostalCode('DE', '10551', 52.525011, 13.369438);
 

--- a/Tests/Doctrine/Query/Mysql/GeoDistanceTest.php
+++ b/Tests/Doctrine/Query/Mysql/GeoDistanceTest.php
@@ -14,24 +14,31 @@ use Craue\GeoBundle\Tests\IntegrationTestCase;
 class GeoDistanceTest extends IntegrationTestCase {
 
 	/**
-	 * @var bool
+	 * @var bool[]
 	 */
-	private static $dummyDataAdded = false;
+	private static $dummyDataAdded = array();
 
-	protected function setUp() {
-		$this->initClient(array(), !self::$dummyDataAdded);
+	protected function prepareDatabase($platform, $config, $requiredExtension) {
+		if (!array_key_exists($platform, self::$dummyDataAdded)) {
+			self::$dummyDataAdded[$platform] = false;
+		}
 
-		// There must be some data in the table to get a result at all, but it's fine to only add the dummy data once.
-		if (!self::$dummyDataAdded) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config), !self::$dummyDataAdded[$platform]);
+
+		// There must be some data in the table to get a result at all, but it's fine to only add the dummy data once (per platform).
+		if (!self::$dummyDataAdded[$platform]) {
 			$this->persistDummyGeoPostalCodes(1);
-			self::$dummyDataAdded = true;
+			self::$dummyDataAdded[$platform] = true;
 		}
 	}
 
 	/**
 	 * @dataProvider dataGeoDistance
 	 */
-	public function testGeoDistance($latOrigin, $lngOrigin, $latDestination, $lngDestination, $expectedDistance) {
+	public function testGeoDistance($platform, $config, $requiredExtension,
+			$latOrigin, $lngOrigin, $latDestination, $lngDestination, $expectedDistance) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$qb = $this->getRepo()->createQueryBuilder('poi')
 			->select('GEO_DISTANCE(:latOrigin, :lngOrigin, :latDestination, :lngDestination)')
 			->setParameter('latOrigin', $latOrigin)
@@ -45,12 +52,12 @@ class GeoDistanceTest extends IntegrationTestCase {
 	}
 
 	public function dataGeoDistance() {
-		return array(
+		return self::duplicateTestDataForEachPlatform(array(
 			array(52.392759, 13.065135, 52.392759, 13.065135, 0),
 			array(52.392759, 13.065135, 52.525011, 13.369438, 25.32498093345365),
 			array(-43.5131367, 172.5990772, -43.8951617, 171.7203311, 82.42610380554926),
 			array(-0.1865943, -78.4305382, 0.3516889, -78.1234253, 68.91091929958483),
-		);
+		));
 	}
 
 }

--- a/Tests/Doctrine/Query/Mysql/TimingTest.php
+++ b/Tests/Doctrine/Query/Mysql/TimingTest.php
@@ -16,30 +16,44 @@ class TimingTest extends IntegrationTestCase {
 	const NUMBER_OF_POIS = 50000;
 
 	/**
-	 * @var bool
+	 * @var bool[]
 	 */
-	private static $dummyDataAdded = false;
+	private static $dummyDataAdded = array();
 
-	protected function setUp() {
-		$this->initClient(array(), !self::$dummyDataAdded);
+	protected function prepareDatabase($platform, $config, $requiredExtension) {
+		if (!array_key_exists($platform, self::$dummyDataAdded)) {
+			self::$dummyDataAdded[$platform] = false;
+		}
 
-		// Only add the dummy data once as it takes quite some time.
-		if (!self::$dummyDataAdded) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config), !self::$dummyDataAdded[$platform]);
+
+		// Only add the dummy data once (per platform) as it takes quite some time.
+		if (!self::$dummyDataAdded[$platform]) {
 			$this->persistDummyGeoPostalCodes(static::NUMBER_OF_POIS);
-			self::$dummyDataAdded = true;
+			self::$dummyDataAdded[$platform] = true;
 		}
 	}
 
-	public function testTimingGeoDistance_withRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistance_withRadius($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistance(52.1, 13.1, 1);
 		$duration = microtime(true) - $startTime;
-		$this->assertLessThan(0.4, $duration);
+		$this->assertLessThan($platform === self::PLATFORM_POSTGRESQL ? 0.5 : 0.4, $duration);
 
 		$this->assertEquals(854, count($result));
 	}
 
-	public function testTimingGeoDistance_withRadius_optimized() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistance_withRadius_optimized($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistance(52.1, 13.1, 1, true);
 		$duration = microtime(true) - $startTime;
@@ -48,7 +62,12 @@ class TimingTest extends IntegrationTestCase {
 		$this->assertEquals(854, count($result));
 	}
 
-	public function testTimingGeoDistance_withoutRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistance_withoutRadius($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistance(52.1, 13.1);
 		$duration = microtime(true) - $startTime;
@@ -57,29 +76,44 @@ class TimingTest extends IntegrationTestCase {
 		$this->assertCount(static::NUMBER_OF_POIS, $result);
 	}
 
-	public function testTimingGeoDistanceByPostalCode_withRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistanceByPostalCode_withRadius($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '123', 1);
 		$duration = microtime(true) - $startTime;
-		$this->assertLessThan(2.8, $duration);
+		$this->assertLessThan($platform === self::PLATFORM_POSTGRESQL ? 7 : 2.8, $duration);
 
 		$this->assertEquals(1703, count($result));
 	}
 
-	public function testTimingGeoDistanceByPostalCode_withRadius_optimized() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistanceByPostalCode_withRadius_optimized($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '123', 1, true);
 		$duration = microtime(true) - $startTime;
-		$this->assertLessThan(0.65, $duration);
+		$this->assertLessThan($platform === self::PLATFORM_POSTGRESQL ? 0.7 : 0.65, $duration);
 
 		$this->assertEquals(1703, count($result));
 	}
 
-	public function testTimingGeoDistanceByPostalCode_withoutRadius() {
+	/**
+	 * @dataProvider getPlatformConfigs
+	 */
+	public function testTimingGeoDistanceByPostalCode_withoutRadius($platform, $config, $requiredExtension) {
+		$this->prepareDatabase($platform, $config, $requiredExtension);
+
 		$startTime = microtime(true);
 		$result = $this->getPoisPerGeoDistanceByPostalCode('DE', '123');
 		$duration = microtime(true) - $startTime;
-		$this->assertLessThan(15, $duration);
+		$this->assertLessThan($platform === self::PLATFORM_POSTGRESQL ? 16 : 15, $duration);
 
 		$this->assertCount(static::NUMBER_OF_POIS, $result);
 	}

--- a/Tests/config/config.yml
+++ b/Tests/config/config.yml
@@ -1,7 +1,7 @@
 doctrine:
   dbal:
     charset: UTF8
-    driver: pdo_mysql
+    driver: ~
     host: 127.0.0.1
     port: ~
     dbname: test

--- a/Tests/config/config_flavor_invalid.yml
+++ b/Tests/config/config_flavor_invalid.yml
@@ -1,0 +1,2 @@
+craue_geo:
+  flavor: invalid

--- a/Tests/config/config_flavor_mysql.yml
+++ b/Tests/config/config_flavor_mysql.yml
@@ -1,0 +1,6 @@
+doctrine:
+  dbal:
+    driver: pdo_mysql
+
+craue_geo:
+  flavor: mysql

--- a/Tests/config/config_flavor_none.yml
+++ b/Tests/config/config_flavor_none.yml
@@ -1,0 +1,6 @@
+doctrine:
+  dbal:
+    driver: pdo_mysql
+
+craue_geo:
+  flavor: none

--- a/Tests/config/config_flavor_postgresql.yml
+++ b/Tests/config/config_flavor_postgresql.yml
@@ -1,0 +1,6 @@
+doctrine:
+  dbal:
+    driver: pdo_pgsql
+
+craue_geo:
+  flavor: postgresql

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.3.x-dev"
+			"dev-master": "1.4.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
This PR replaces #14 by adding full support (and tests) for PostgreSQL.

Several issues were taken care of:
- PostgreSQL doesn't support aliases in a HAVING (or WHERE) clause --> [error](https://travis-ci.org/craue/CraueGeoBundle/jobs/216701637#L248)
- PostgreSQL requires explicit casts for parameterized values in math functions --> [error](https://travis-ci.org/craue/CraueGeoBundle/jobs/216701637#L296)
- PostgreSQL requires selected columns to appear in a GROUP BY clause --> [error](https://travis-ci.org/craue/CraueGeoBundle/jobs/216739631#L245)

closes #13
closes #14