### PR TITLE
chore: fix symfony 6.3 deprecation notices

### DIFF
--- a/CraueGeoBundle.php
+++ b/CraueGeoBundle.php
@@ -15,6 +15,8 @@ class CraueGeoBundle extends Bundle {
 
 	/**
 	 * {@inheritDoc}
+     *
+     * @return void
 	 */
 	public function build(ContainerBuilder $container) {
 		parent::build($container);

--- a/DependencyInjection/CraueGeoExtension.php
+++ b/DependencyInjection/CraueGeoExtension.php
@@ -17,6 +17,8 @@ class CraueGeoExtension extends Extension implements PrependExtensionInterface {
 
 	/**
 	 * {@inheritDoc}
+     *
+     * @return void
 	 */
 	public function load(array $config, ContainerBuilder $container) {
 	}


### PR DESCRIPTION
[Application] May 31 14:41:51 |INFO   | DEPREC User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Craue\GeoBundle\CraueGeoBundle" now to avoid errors or add an explicit @return annotation to suppress this message. 

Method "Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface::prepend()" might add "void" as a native return type declaration in the future. Do the same in implementation "Craue\GeoBundle\DependencyInjection\CraueGeoExtension" now to avoid errors or add an explicit @return annotation to suppress this message.